### PR TITLE
Add feature to install DNSMasq service

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -37,4 +37,27 @@ disk_file_path: /mnt/microshift-storage-file
 disk_file_size: 20G
 vg_name: rhel
 
+# Configure the DNSMasq service to redirect service addresses to proper
+# ip address.
+configure_dnsmasq: true
+# Set the ip address of remote Microshift machine to configure local
+# DNSMasq service to redirect DNS queries for {{ fqdn }} domain
+# to the Microshift machine. If the value is empty, it will configure
+# first IP address of loadbalancer or Openshift Router.
+microshift_frontend_address: ""
+# Additional addresses that should be resolved by the DNSMasq and redirected
+# to microshift_frontend_address (if configure). Otherwise redirect to
+# loadbalancer or Openshift router.
+microshift_additional_addresses:
+  - "{{ fqdn }}"
+# Set the cloud provider DNS IP addresses. Replace below DNS servers with your
+# Cloud provider DNS addresses.
+cloudprovider_dns:
+  - 1.1.1.1
+  - 1.0.0.1
+# Set the DNS ip addresses for public DNS.
+public_dns:
+  - 8.8.8.8
+  - 9.9.9.9
+
 overwrite_container_policy: false

--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -1,0 +1,85 @@
+---
+- name: Install DNSMasq
+  become: true
+  ansible.builtin.package:
+    name: dnsmasq
+    state: present
+
+- name: Get the LoadBalander ip address or Openshift Router ip address
+  when: not microshift_frontend_address
+  block:
+    - name: Create script to get ingress ip address
+      ansible.builtin.copy:
+        content: |
+          #!/bin/bash
+          IP=$(oc get svc -n openshift-ingress router-internal-default -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          if [ -z "${IP}" ]; then
+              IP=$(oc get svc -n openshift-ingress router-internal-default -o jsonpath='{.spec.clusterIP}');
+          fi
+          echo "${IP}"
+        dest: "~{{ ansible_user }}/recognize_ingress_ip.sh"
+        mode: 0755
+
+    - name: Get Ingress IP Address
+      ansible.builtin.command: "~{{ ansible_user }}/recognize_ingress_ip.sh"
+      register: _lb_ip
+
+    - name: Set the LB or Router IP address as default address for FQDN
+      ansible.builtin.set_fact:
+        microshift_frontend_address: "{{ _lb_ip.stdout }}"
+
+- name: Change DNSMasq configuration
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/dnsmasq.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  loop:
+    - regexp: "^#server=/3.168.192.in-addr.arpa/10.1.2.3"
+      line: "server={{ cloudprovider_dns | default(public_dns) | random }}"
+    - regexp: '^# server=10.1.2.3@eth1'
+      line: "server={{ public_dns | random}}"
+    - regexp: "^interface=lo"
+      line: "#interface=lo"
+    - regexp: "^#address=\/double-click.net\/127.0.0.1"
+      line: "address=/{{ fqdn }}/127.0.0.1"
+
+# NOTE: Add Openstack k8s domains
+- name: Add new addresses to bind to the ingress
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/dnsmasq.conf
+    line: "address=/{{ item }}/{{ microshift_frontend_address }}"
+  loop: "{{ microshift_additional_addresses }}"
+  when: microshift_frontend_address
+
+# FROM: https://devopstales.github.io/linux/networkmanagger-dnsmasq/
+- name: Add dnsmasq rule for NetworkManager
+  become: true
+  ansible.builtin.copy:
+    content: |
+      [main]
+      dns=dnsmasq
+    dest: /etc/NetworkManager/conf.d/00-microshift-use-dnsmasq.conf
+
+- name: Change resolv.conf
+  become: true
+  ansible.builtin.copy:
+    content: |
+      # NOTE: The nameserver ip addresses are set in /etc/dnsmasq.conf
+      nameserver 127.0.0.1
+    dest: /etc/resolv.conf
+
+- name: Restart DNSMasq service
+  become: true
+  ansible.builtin.systemd:
+    name: dnsmasq
+    state: restarted
+    enabled: true
+
+- name: Reload NetworkManager
+  become: true
+  ansible.builtin.systemd:
+    name: NetworkManager
+    state: reloaded
+    enabled: true

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -49,3 +49,7 @@
 
 - name: Create lvm or delete openshift storage
   ansible.builtin.include_tasks: openshift-storage.yaml
+
+- name: Configure DNSMasq
+  ansible.builtin.include_tasks: dnsmasq.yaml
+  when: configure_dnsmasq


### PR DESCRIPTION
The DNSMasq service would be helpful especially for developers, that would try to make a query for new deployed service. It does not need to add each time proper entry into the /etc/hosts to resolve the domain.