### PR TITLE
Revert "Bump Microshift version to 4.13"

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -39,7 +39,7 @@ firewalld_rules_permament: true
 use_copr_microshift: false
 
 # The Microshift version that is available in the repository.
-microshift_version: 4.13
+microshift_version: 4.12
 
 #######################################
 ###              OLM                ###

--- a/tasks/crio.yaml
+++ b/tasks/crio.yaml
@@ -19,7 +19,7 @@
 - name: Use only ipv4
   become: true
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conflist
+    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conf
     dest: /etc/cni/net.d/100-crio-bridge.conf
     mode: "0644"
   notify: Restart crio

--- a/templates/microshift.repo.j2
+++ b/templates/microshift.repo.j2
@@ -1,6 +1,6 @@
 [microshift-rpms]
 name=Puddle of Microshift RPMs
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el{{ ansible_distribution_major_version }}/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el8/os/
 enabled=0
 gpgcheck=0
 skip_if_unavailable=1


### PR DESCRIPTION
Some images might not be accessible without setting "overwrite_container_policy" variable to  true.