### PR TITLE
Bump Microshift version to 4.13

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -39,7 +39,7 @@ firewalld_rules_permament: true
 use_copr_microshift: false
 
 # The Microshift version that is available in the repository.
-microshift_version: 4.12
+microshift_version: 4.13
 
 #######################################
 ###              OLM                ###

--- a/tasks/crio.yaml
+++ b/tasks/crio.yaml
@@ -19,7 +19,7 @@
 - name: Use only ipv4
   become: true
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conf
+    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conflist
     dest: /etc/cni/net.d/100-crio-bridge.conf
     mode: "0644"
   notify: Restart crio

--- a/templates/microshift.repo.j2
+++ b/templates/microshift.repo.j2
@@ -1,6 +1,6 @@
 [microshift-rpms]
 name=Puddle of Microshift RPMs
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el8/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el{{ ansible_distribution_major_version }}/os/
 enabled=0
 gpgcheck=0
 skip_if_unavailable=1


### PR DESCRIPTION
The new Microshift version has packages also for RHEL 9 base system. Earlier we revert that change, due topolvm was not deployed correctly because of changes in package gnupg2. More info [1][2].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2184640
[2] https://bugs.launchpad.net/tripleo/+bug/2015309