### PR TITLE
Add capability to use version 4.12

### DIFF
--- a/tasks/crio.yaml
+++ b/tasks/crio.yaml
@@ -16,13 +16,23 @@
     - skip_ansible_lint
   register: _crio_version
 
-- name: Use only ipv4
+- name: Use only ipv4 - new Microshift
   become: true
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conflist
     dest: /etc/cni/net.d/100-crio-bridge.conf
     mode: "0644"
   notify: Restart crio
+  when: microshift_version > 4.12
+
+- name: Use only ipv4 - legacy Microshift
+  become: true
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conf
+    dest: /etc/cni/net.d/100-crio-bridge.conf
+    mode: "0644"
+  notify: Restart crio
+  when: microshift_version <= 4.12
 
 - name: Apply container policy from crc
   become: true

--- a/templates/microshift.repo.j2
+++ b/templates/microshift.repo.j2
@@ -1,6 +1,10 @@
 [microshift-rpms]
 name=Puddle of Microshift RPMs
+{% if microshift_version == 4.12 %}
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el8/os/
+{% else %}
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el{{ ansible_distribution_major_version }}/os/
+{% endif %}
 enabled=0
 gpgcheck=0
 skip_if_unavailable=1


### PR DESCRIPTION
The new Microshift version has more pod security enhancements, that can break the operator deployment.
Until new patches that fixes the deployment are not merged, let's add back capability to version 4.12 to continue develop the operator (sf-operator).