### PR TITLE
Rework the OLM play

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -47,6 +47,7 @@ microshift_version: 4.13
 
 # Install the OLM - https://olm.operatorframework.io/
 setup_olm: false
+olm_version: "v0.24.0"
 
 # Location where the additional projects should be keeped.
 # For example, if `setup_olm` is enabled, it will use Git to clone project
@@ -54,10 +55,7 @@ setup_olm: false
 repo_dir: "~{{ ansible_user }}/repos"
 
 # Version of the Operator SDK
-operator_sdk_version: "v1.21.0"
-
-# The URL path where the Operator SDK is located
-operator_sdk_url: "https://github.com/operator-framework/operator-sdk"
+operator_sdk_version: "v1.28.0"
 
 #######################################
 ### Persistent volume configuration ###

--- a/tasks/olm.yaml
+++ b/tasks/olm.yaml
@@ -1,26 +1,28 @@
----
-- name: Clone OLM operator-sdk
-  ansible.builtin.git:
-    repo: "{{ operator_sdk_url }}"
-    dest: "{{ repo_dir }}/operator-sdk"
-    version: "{{ operator_sdk_version }}"
+- name: Ensure installation directory
+  file:
+    path: "{{ repo_dir }}"
+    state: directory
 
-- name: Build Operator SDK
-  community.general.make:
-    target: build
-    chdir: "{{ repo_dir }}/operator-sdk"
+- name: Fetch operator-sdk
+  ansible.builtin.uri:
+    url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_amd64
+    dest: "{{ repo_dir }}/operator-sdk"
+    mode: "755"
+    status_code:
+      - 200
+      - 304
 
 - name: Check if OLM is installed
-  ansible.builtin.shell: |
-    build/operator-sdk olm status
+  ansible.builtin.command:
+    "{{ repo_dir }}/operator-sdk olm status"
   register: olm_status
-  args:
-    chdir: "{{ repo_dir }}/operator-sdk"
   failed_when: olm_status.rc not in [0, 1]
 
 - name: Install OLM with SDK
-  ansible.builtin.shell: |
-    build/operator-sdk olm install
-  args:
-    chdir: "{{ repo_dir }}/operator-sdk"
+  ansible.builtin.command:
+    "{{ repo_dir }}/operator-sdk olm install --version {{ olm_version }}"
   when: olm_status.rc != 0
+
+- name: Ensure privileged SCC for OLM
+  ansible.builtin.command:
+    oc adm policy add-scc-to-user privileged system:serviceaccount:olm:default


### PR DESCRIPTION
- Fetch the operator-sdk binary
- Use last version by default for operator sdk
- Use version for OLM and default to last stable
- Fix SCC for the OLM namespace default service user