### PR TITLE
Flush handlers afer dnsmasq is configured

### DIFF
--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -74,3 +74,6 @@
       dns=dnsmasq
     dest: /etc/NetworkManager/conf.d/00-microshift-use-dnsmasq.conf
   notify: Reload NetworkManager
+
+- name: Flush handlers
+  meta: flush_handlers


### PR DESCRIPTION
The handlers should be triggered before OLM setup will be executed.