### PR TITLE
Listen dnsmasq also on local ip address

### DIFF
--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -34,7 +34,9 @@
   copy:
     content: |
       ## Created by cloud-init on instance boot automatically, do not edit.
-      ## \n\n# ANSIBLE: This file was commented by Ansible to enable dnsmasq functionality \n\n
+      #
+      ## ANSIBLE: This file was commented by Ansible to enable dnsmasq functionality
+      #
       #[main]
       #dns = none
     dest: /etc/NetworkManager/conf.d/99-cloud-init.conf
@@ -61,6 +63,8 @@
       line: "#interface=lo"
     - regexp: "^#address=\/double-click.net\/127.0.0.1"
       line: "address=/{{ fqdn }}/127.0.0.1"
+    - regexp: "^#listen-address="
+      line: "listen-address={{ ansible_default_ipv4.address }}"
 
 - name: Get the LoadBalander ip address or Openshift Router ip address
   when: not microshift_frontend_address


### PR DESCRIPTION
Listen dnsmasq also on local ip address

This change will enable on dnsmasq listening in NetworkManager also on the
on local ip address of the host. It would be useful, when
someone would like to provide local domains, that can be resolved by the
dnsmasq service inside the OpenShift cluster.
For example, if someone would like to enable resolving hostname:
logserver.sftests.com inside the pod, not by using the Kubernetes like
domain name resolution, it is needed to add a new entry into the dns-default
configmap and the dns query will be forwarded to the dnsmasq on the
host.
Example:

    oc edit configmap -n openshift-dns  dns-default

    (...)
       logserver.sftest.com {
         errors
         cache 30
         forward . <server local ip address that is in dnsmasq.conf>
       }

Then  restart services

    oc -n openshift-dns rollout restart daemonsets dns-default
    oc -n openshift-dns rollout restart daemonsets node-resolver