### PR TITLE
Add support to forward external domains DNS queries to dnsmasq

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -140,5 +140,8 @@ public_dns:
   - 8.8.8.8
   - 9.9.9.9
 
+# A place where openshift-dns corefile will be stored and changed.
+coredns_config_dir: "/etc/coredns-configs"
+
 # Set the cri-o registry policy to pull images even from untrasted registries.
 overwrite_container_policy: false

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -26,3 +26,8 @@
     name: microshift
     state: started
     enabled: true
+
+- name: Restart Openshift DNS
+  ansible.builtin.shell: |
+    kubectl -n openshift-dns rollout restart daemonsets dns-default
+    kubectl -n openshift-dns rollout restart daemonsets node-resolver

--- a/tasks/coredns.yaml
+++ b/tasks/coredns.yaml
@@ -1,0 +1,77 @@
+---
+# NOTE: We are adding "forward" parameter in the coredns that is
+# resolving DNS queries in dnsmasq that is running to the host.
+# With such way, we are able to resolve the service public hostname in the pod,
+# so it would be helpful in the CI to simulate deployment in the public
+# OpenShift, where some services are not running directly on that cluster.
+- name: Create dnsmasq modification dir
+  become: true
+  ansible.builtin.file:
+    path: "{{ coredns_config_dir }}"
+    state: directory
+
+- name: Check if DNS backup already exists
+  become: true
+  ansible.builtin.stat:
+    path: /etc/microshift/dns-configmap-default.yaml
+  register: _back_dns_configmap
+
+- name: Make backup of current DNS configmap
+  when: not _back_dns_configmap.stat.exists
+  block:
+    - name: Create dns configmap backup
+      become: true
+      ansible.builtin.shell: |
+        oc --kubeconfig ~{{ ansible_user }}/.kube/config -n openshift-dns get configmap dns-default -o yaml > {{ coredns_config_dir }}/dns-configmap-default.yaml
+
+    - name: Copy the dns-configmap.yaml to safe location
+      become: true
+      ansible.builtin.copy:
+        src: "{{ coredns_config_dir }}/dns-configmap-default.yaml"
+        dest: "/etc/microshift/dns-configmap-default.yaml"
+        mode: "0644"
+        remote_src: true
+
+# To get current core DNS configuration just type:
+# oc -n openshift-dns get configmap dns-default  -o go-template --template '{{.data.Corefile}}'
+- name: Add new domains
+  block:
+    - name: Check if yq already exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/yq
+      register: _yq_bin
+
+    - name: Get yq tool
+      become: true
+      ansible.builtin.get_url:
+        url: https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        dest: /usr/local/bin/yq
+        mode: "0755"
+      when: not _yq_bin.stat.exists
+
+    - name: Create new Corefile
+      become: true
+      ansible.builtin.template:
+        src: "corefile.yaml"
+        dest: "{{ coredns_config_dir }}/corefile.yaml"
+      notify: Restart Openshift DNS
+
+    - name: Dump corefile.yaml into raw content
+      become: true
+      ansible.builtin.shell: |
+        cat {{ coredns_config_dir }}/corefile.yaml | xargs -d $'\n' printf '%s\\n' > {{ coredns_config_dir }}/corefile.raw
+
+    - name: Patch configmap with new content
+      become: true
+      ansible.builtin.shell: |
+        /usr/local/bin/yq ".data.Corefile = \"$(cat {{ coredns_config_dir }}/corefile.raw)\"" /etc/microshift/dns-configmap-default.yaml > {{ coredns_config_dir }}/patched-corefile.yaml
+
+    - name: Remove keys that will block coredns configmap update
+      become: true
+      ansible.builtin.shell: |
+        sed -i '/  creationTimestamp:\|  resourceVersion:\|  uid:/d' {{ coredns_config_dir }}/patched-corefile.yaml
+
+    - name: Apply new coredns configmap
+      ansible.builtin.shell: |
+        kubectl apply -f {{ coredns_config_dir }}/patched-corefile.yaml
+      notify: Restart Openshift DNS

--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -101,6 +101,7 @@
   become: true
   ansible.builtin.copy:
     content: |
+      # MANAGED BY ANSIBLE
       [main]
       dns=dnsmasq
     dest: /etc/NetworkManager/conf.d/00-microshift-use-dnsmasq.conf

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -53,6 +53,9 @@
   ansible.builtin.include_tasks: dnsmasq.yaml
   when: configure_dnsmasq
 
+- name: Configure additional domains
+  ansible.builtin.include_tasks: coredns.yaml
+
 - name: Setup OLM
   ansible.builtin.include_tasks: olm.yaml
   when: setup_olm

--- a/templates/corefile.yaml
+++ b/templates/corefile.yaml
@@ -1,0 +1,29 @@
+.:5353 {
+    bufsize 512
+    errors
+    log . {
+        class error
+    }
+    health {
+        lameduck 20s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus 127.0.0.1:9153
+
+    forward . {{ ansible_default_ipv4.address }}:53
+
+    forward . /etc/resolv.conf {
+        policy sequential
+    }
+    cache 900 {
+        denial 9984 30
+    }
+    reload
+}
+hostname.bind:5353 {
+    chaos
+}


### PR DESCRIPTION
That feature will be mostly used by the CI for simulating the external domains that exists normaly in the Internet.
For example, if domain '.sftests.com' have many subdomains and not each domain is registered domain in the Openshift cluster and the domain is just for test (not registered in any DNS authority) it will fail name resolution inside the pod with an error:

    "curl: (6) Could not resolve host: test.sftests.com"

In that case, we are adding custom domain inside the codedns configuration configmap, which will forward the DNS queries made for that domain to the dnsmasq, which is installed on the host. The dnsmasq (which is started by NetworkManager) have proper entries to resolve the domain.