### PR TITLE
Set lvm volumes to be active after reboot

### DIFF
--- a/files/start-lvm.sh
+++ b/files/start-lvm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in $(lvscan | awk '{print $2}' | sed "s/'//g"); do
+    lvchange -ay ${i};
+done

--- a/tasks/openshift-storage.yaml
+++ b/tasks/openshift-storage.yaml
@@ -49,6 +49,13 @@
           ansible.builtin.command: losetup -f
           register: loop_device
 
+        - name: Create script to start lvm volumes after reboot
+          become: true
+          copy:
+            src: start-lvm.sh
+            dest: /usr/local/bin/start-lvm.sh
+            mode: "0755"
+
         - name: Create loop device service
           become: true
           ansible.builtin.template:

--- a/templates/microshift-loop-device.service.j2
+++ b/templates/microshift-loop-device.service.j2
@@ -3,17 +3,18 @@ Description=Setup loopback device
 DefaultDependencies=no
 Conflicts=umount.target
 ConditionPathExists={{ disk_file_path }}
-Before=microshift.service
-After=systemd-udevd.service
+Before=local-fs.target microshift.service
+After=systemd-udevd.service lvm2-monitor.service
 
 [Service]
 ExecStartPre=/sbin/modprobe loop
 ExecStart=/sbin/losetup {{ loop_device.stdout }} {{ disk_file_path }}
+ExecStartPost=/usr/local/bin/start-lvm.sh
 ExecStop=/sbin/losetup -d {{ loop_device.stdout }}
 Type=oneshot
 TimeoutSec=60
 RemainAfterExit=yes
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=local-fs-pre.target
 Also=systemd-udevd.service


### PR DESCRIPTION
After the reboot, the volume group is available:

    $ vgdisplay
      --- Volume group ---
      VG Name               rhel
      (...)

and the volumes are also available:

    $ lvdisplay
      --- Logical volume ---
      LV Path                /dev/rhel/37449bb2-9190-4846-8ec1-562361e0fdbc
      LV Name                37449bb2-9190-4846-8ec1-562361e0fdbc
      (...)

but the directory /dev/rhel is not available, so by checking:

    $ lvscan
      inactive          '/dev/rhel/37449bb2-9190-4846-8ec1-562361e0fdbc' [1,00 GiB] inherit
      inactive          '/dev/rhel/48917243-f3e8-46b5-be4d-8b40b5e0a8ec' [1,00 GiB] inherit
      (...)

shows that all volumes are inactive state.
By iterating on all inactive volumes and execute command: vchange -ay <volume>
starts the volume mapping and the /dev/rhel is available. After a while, all pods that uses pv are starting.