### PR TITLE
Add post step to configure coredns after Microshift restart

### DIFF
--- a/files/wait-for-microshift.sh
+++ b/files/wait-for-microshift.sh
@@ -4,7 +4,15 @@ for i in {1..20}; do
     echo "Ensuring that containers are spawned... ${i}"
     count=$(oc get pods --all-namespaces | grep openshift | grep -vic 'running')
     if [ "$count" -eq "0" ]; then
-        echo "Microshift is deployed, we can continue..."
+        # Ensure that all pods are in expected count
+        for ns in $(oc get pods --all-namespaces | grep openshift | awk '{print $1}'); do
+            echo "Checking pods from namespace: $ns";
+            if ! kubectl -n "$ns" wait --for=condition=Ready pod --all; then
+                echo -e "\nThe namespace $ns pods count does not match. Waiting..."
+                sleep 15
+            fi
+        done
+        echo -e "\nMicroshift is deployed, we can continue..."
         break
     else
         echo "The Microshift containers are not ready..."

--- a/tasks/coredns.yaml
+++ b/tasks/coredns.yaml
@@ -35,3 +35,22 @@
 
 - name: Execute the reconfigure-coredns script
   ansible.builtin.command: /usr/local/bin/reconfigure-coredns.sh
+
+- name: Add post run command to overwrite Core DNS
+  become: true
+  community.general.ini_file:
+    path: /usr/lib/systemd/system/microshift.service
+    section: Service
+    option: ExecStartPost
+    value: /bin/bash -c "/usr/local/bin/wait-for-microshift.sh && reconfigure-coredns.sh.j2 || true"
+    backup: true
+    no_extra_spaces: true
+  register: _microshift_service_config
+
+- name: Reload systemd daemon
+  become: true
+  ansible.builtin.systemd:
+    name: microshift
+    state: restarted
+    daemon_reload: true
+  when: _microshift_service_config.changed

--- a/tasks/wait-for-microshift.yaml
+++ b/tasks/wait-for-microshift.yaml
@@ -1,16 +1,16 @@
 ---
 - name: Check if verify Microshift script exists
   ansible.builtin.stat:
-    path: /tmp/wait-for-microshift.sh
+    path: /usr/local/bin/wait-for-microshift.sh
   register: _script_exists
 
 - name: Copy script to verify deployment
+  become: true
   ansible.builtin.copy:
     src: wait-for-microshift.sh
-    dest: /tmp/wait-for-microshift.sh
+    dest: /usr/local/bin/wait-for-microshift.sh
     mode: "0755"
   when: not _script_exists.stat.exists
 
 - name: Check if all containers are up and ready
-  ansible.builtin.command: /tmp/wait-for-microshift.sh
-  changed_when: true
+  ansible.builtin.command: /usr/local/bin/wait-for-microshift.sh


### PR DESCRIPTION
After reboot, when the Microshift service is restarted, the coredns configuration has been changed to default one, which does not have configuration to forward the DNS queries to dnsmasq.