### PR TITLE
Set dnsmasq nameserver as first nameserver in /etc/resolv.conf

### DIFF
--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -120,6 +120,7 @@
     path: /etc/resolv.conf
     insertbefore: '^nameserver'
     line: 'nameserver {{ ansible_default_ipv4.address }}'
+    firstmatch: true
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
When there was many nameserver entries available in the /etc/resolv.conf file, the lineinfile module was adding the dnsmasq entry before last match, not before first one.