### PR TITLE
Ensure OpenShift DNS has been restarted after changing nameserver

### DIFF
--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -26,3 +26,7 @@
     name: microshift
     state: started
     enabled: true
+
+- name: Restart Openshift DNS
+  ansible.builtin.shell: |
+    kubectl -n openshift-dns rollout restart daemonsets dns-default

--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -121,6 +121,7 @@
     insertbefore: '^nameserver'
     line: 'nameserver {{ ansible_default_ipv4.address }}'
     firstmatch: true
+  notify: Restart Openshift DNS
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
It can happen on the slow host, that the configuration related to the nameserver is not applied correctly in the OpenShift DNS, so the queries are not going to the dnsmasq.