### PR TITLE
Print all resources when wait-for-microshift script fails

### DIFF
--- a/tasks/wait-for-microshift.yaml
+++ b/tasks/wait-for-microshift.yaml
@@ -14,3 +14,8 @@
 - name: Check if all containers are up and ready
   ansible.builtin.command: /tmp/wait-for-microshift.sh
   changed_when: true
+  register: _microshift_svc_status
+
+- name: Print all resources when wait for microshift fail
+  ansible.builtin.command: oc get all --all-namespaces
+  when: _microshift_svc_status.rc == 1


### PR DESCRIPTION
From time to time we spotted that the wait-for-microshift.sh script fails from unknown reason.
This commit will help to find broken resource.