### PR TITLE
Check once again resource state after fail

### DIFF
--- a/tasks/wait-for-microshift.yaml
+++ b/tasks/wait-for-microshift.yaml
@@ -15,7 +15,12 @@
   ansible.builtin.command: /tmp/wait-for-microshift.sh
   changed_when: true
   register: _microshift_svc_status
+  ignore_errors: true
 
 - name: Print all resources when wait for microshift fail
   ansible.builtin.command: oc get all --all-namespaces
   when: _microshift_svc_status.rc == 1
+
+- name: Check once again if all containers are up
+  ansible.builtin.command: /tmp/wait-for-microshift.sh
+  changed_when: true


### PR DESCRIPTION
The previous commit [1] is not ignoring errors, when the script fails.

[1] https://github.com/openstack-k8s-operators/ansible-microshift-role/pull/39