### PR TITLE
Add experimental feature: mount etcd to ramdisk

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -185,3 +185,11 @@ public_dns:
 
 # Set the cri-o registry policy to pull images even from untrasted registries.
 overwrite_container_policy: false
+
+# Experimental features: you should not use it on the production!
+# That feature might be useful for the CI, especially when the disk is slow.
+etcd_on_ramdisk: false
+# Path for the etcd directory used by the microshift-etcd service.
+ramdisk_path: /var/lib/microshift/etcd
+# Ramdisk size for etcd service
+ramdisk_size: 512m

--- a/tasks/etcd_ramdisk.yaml
+++ b/tasks/etcd_ramdisk.yaml
@@ -1,0 +1,31 @@
+---
+- name: Create directory for etcd
+  become: true
+  ansible.builtin.file:
+    path: "{{ ramdisk_path }}"
+    state: directory
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Mount ramdisk
+  become: true
+  ansible.posix.mount:
+    src: tmpfs
+    name: "{{ ramdisk_path }}"
+    fstype: tmpfs
+    state: mounted
+    opts: "defaults,size={{ ramdisk_size }}"
+
+- name: Set proper permissions after mount
+  become: true
+  ansible.builtin.file:
+    path: "{{ ramdisk_path }}"
+    state: directory
+    mode: 0700
+    owner: root
+    group: root
+
+- name: Set proper SELinux context
+  become: true
+  ansible.builtin.command: restorecon -F {{ ramdisk_path }}

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -28,6 +28,10 @@
 - name: Prepare firewall
   ansible.builtin.include_tasks: firewall.yaml
 
+- name: Use ramdisk for etcd service
+  ansible.builtin.include_tasks: etcd_ramdisk.yaml
+  when: etcd_on_ramdisk
+
 - name: Setup Microshift
   ansible.builtin.include_tasks: microshift.yaml
 


### PR DESCRIPTION
That feature might help in the CI gates, when the host storage is not so fast.