### PR TITLE
crio.yaml - add retries/delay to get_url task

### DIFF
--- a/tasks/crio.yaml
+++ b/tasks/crio.yaml
@@ -25,6 +25,8 @@
     mode: "0644"
   notify: Restart crio
   when: microshift_version > 4.12
+  retries: 6
+  delay: 10
 
 - name: Use only ipv4 - legacy Microshift
   become: true
@@ -34,6 +36,8 @@
     mode: "0644"
   notify: Restart crio
   when: microshift_version <= 4.12
+  retries: 6
+  delay: 10
 
 - name: Apply container policy from crc
   become: true


### PR DESCRIPTION
This change attempts to reduce failures such as:

TASK [ansible-microshift-role : Use only ipv4 - new Microshift] ****************
fatal: [microshift]: FAILED! => {"changed": false, "dest": "/etc/cni/net.d/100-crio-bridge.conf", "elapsed": 10, "msg": "Connection failure: The read operation timed out", "url": "https://raw.githubusercontent.com/cri-o/cri-o/v1.26.4/contrib/cni/11-crio-ipv4-bridge.conflist"}