### PR TITLE
Add workaround for random DNS when cloudprovider_dns is empty

### DIFF
--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -58,7 +58,7 @@
     line: "{{ item.line }}"
   loop:
     - regexp: "^#server=/3.168.192.in-addr.arpa/10.1.2.3"
-      line: "server={{ cloudprovider_dns | default(public_dns) | random }}"
+      line: "server={{ (cloudprovider_dns | random if cloudprovider_dns else public_dns | random) }}"
     - regexp: '^# server=10.1.2.3@eth1'
       line: "server={{ public_dns | random }}"
     - regexp: "^interface=lo"


### PR DESCRIPTION
The random function in Ansible is raising an error:

    Cannot choose from an empty sequence

when the cloudprovider_dns is empty list.