### PR TITLE
Remove Jinja2 Templating Delimiters from Conditional Statement

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -39,7 +39,7 @@
       dest: lvmd.yaml
     - var_name: microshift_ovn
       dest: ovn.yaml
-  when: "{{ vars[item.var_name] }}"
+  when: vars[item.var_name]
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
It fixes the following warning:
```
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{
```