### PR TITLE
Install dnsmasq even when NetworkManager dnsmasq plugin enabled

### DIFF
--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Disable dnsmasq service
+  become: true
+  ansible.builtin.systemd:
+    name: dnsmasq
+    state: stopped
+    enabled: false
+
 - name: Reload NetworkManager
   become: true
   ansible.builtin.systemd:

--- a/tasks/dnsmasq.yaml
+++ b/tasks/dnsmasq.yaml
@@ -3,6 +3,13 @@
 # to the systemd-resolved service, but after a test, for dnsmasq and Microshift 4.12,
 # it is better when the dnsmasq service is deployed after the Microshift pods are
 # running.
+- name: Install DNSMasq
+  become: true
+  ansible.builtin.package:
+    name: dnsmasq
+    state: present
+  notify: Disable dnsmasq service
+
 - name: Check if 99-cloud-init.conf exists
   become: true
   ansible.builtin.stat:


### PR DESCRIPTION
The plugin requires to install dnsmasq package, due it will raise an error:

    dns-mgr: init: dns=dnsmasq,systemd-resolved rc-manager=unmanaged, plugin=dnsmasq
    dns-mgr: update-dns: plugin dnsmasq update failed: could not find dnsmasq binary