### PR TITLE
openshift-storage: Add check to not create vg if it exists

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -144,6 +144,9 @@ disk_file_sparsed: false
 # Default value for Microshift is `rhel`.
 vg_name: rhel
 
+# Create vg if it doesn't exist
+vg_create: true
+
 ########################
 ### Additional users ###
 ########################

--- a/tasks/openshift-storage.yaml
+++ b/tasks/openshift-storage.yaml
@@ -1,4 +1,13 @@
 ---
+- name: Get existing volume groups
+  ansible.builtin.shell: "vgs"
+  become: true
+  register: _vgs
+
+- ansible.builtin.set_fact:
+    vg_create: false
+  when: vg_name in _vgs.stdout
+
 - name: Delete openshift-storage if needed
   when: delete_openshift_storage
   block:
@@ -21,7 +30,9 @@
       changed_when: true
 
 - name: Create LVM on loop device to deploy openshift storage with topolvm
-  when: not delete_openshift_storage
+  when:
+    - not delete_openshift_storage
+    - not vg_create
   block:
     - name: Check if file already exists
       become: true


### PR DESCRIPTION
When a vg exists with vg_name exists it's not needed to create a sparse file. This change ensure an existing vg will be used