### PR TITLE
Remove openshift-storage deletion feature

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -83,7 +83,6 @@ microshift_ovn: {}
 #   externalGatewayInterface: ""
 # mtu: 1500
 
-
 #######################################
 ###              OLM                ###
 #######################################
@@ -123,11 +122,11 @@ pv_count:
 ###        Openshift Storage        ###
 #######################################
 #
-# Set to true if the openshift-storage should be deleted.
-# NOTE: After restart the Microshift service, the openshift-storage will be
-# recreated. In that case, it is recommended to set the value to false and
-# it will create a LVM base on loopback file disk.
-delete_openshift_storage: false
+# Create expected VG "rhel" (for topolvm/openshift-storage)
+# The VG is created inside a file as a loop device. This is a handy solution
+# for the CI and Microshift testing purpose.
+# When the VG is already available on the machine then not VG is populated.
+vg_create: true
 
 # Set the path for a file, where later Ansible would create a LVM partition.
 # It would be needed when `delete_openshift_storage` is set to false.
@@ -143,9 +142,6 @@ disk_file_sparsed: false
 # Name of the volume group used by the openshift-storage to deploy topolvm.
 # Default value for Microshift is `rhel`.
 vg_name: rhel
-
-# Create vg if it doesn't exist
-vg_create: true
 
 ########################
 ### Additional users ###

--- a/files/wait-for-microshift.sh
+++ b/files/wait-for-microshift.sh
@@ -23,4 +23,5 @@ done
 # Normally, the script should finished in the for loop, but if it's not
 # it should exit with an error.
 echo -e "\nSomthing is not deployed in Microshift. Exit!\n"
+oc get pods --all-namespaces | grep openshift
 exit 1

--- a/tasks/openshift-storage.yaml
+++ b/tasks/openshift-storage.yaml
@@ -8,30 +8,8 @@
     vg_create: false
   when: vg_name in _vgs.stdout
 
-- name: Delete openshift-storage if needed
-  when: delete_openshift_storage
-  block:
-    # NOTE: The Openshift storage uses topolvm, that requires additional volume,
-    # which is not necessary for us, due we mostly use that playbook for CI.
-    - name: Check if openshift-storage namespace exists
-      ansible.builtin.command: oc get namespace openshift-storage
-      register: _openshift_storage_ns
-      failed_when: _openshift_storage_ns.rc not in [0, 1]
-      changed_when: true
-
-    - name: Delete openshift storage namespace
-      ansible.builtin.command: oc delete namespace openshift-storage
-      when: _openshift_storage_ns.rc == 0
-      changed_when: true
-
-    - name: Delete topolvm-provisioner storageclass
-      ansible.builtin.command: oc delete storageclass topolvm-provisioner
-      when: _openshift_storage_ns.rc == 0
-      changed_when: true
-
 - name: Create LVM on loop device to deploy openshift storage with topolvm
   when:
-    - not delete_openshift_storage
     - not vg_create
   block:
     - name: Check if file already exists

--- a/tasks/openshift-storage.yaml
+++ b/tasks/openshift-storage.yaml
@@ -9,8 +9,7 @@
   when: vg_name in _vgs.stdout
 
 - name: Create LVM on loop device to deploy openshift storage with topolvm
-  when:
-    - not vg_create
+  when: vg_create
   block:
     - name: Check if file already exists
       become: true


### PR DESCRIPTION
This feature should be avoided as openshift-storage is the supported storage operator of Microshift.

This role provides the capability to setup a "rhel" LVM VG via a file mounted as a loop device. This integrates well with openshift-storage.

There is no clear usecase for the openshift-storage deletion.