### PR TITLE
Use preprovisionned file for crio bridge

### DIFF
--- a/files/crio-bridge.conf
+++ b/files/crio-bridge.conf
@@ -1,0 +1,22 @@
+{
+  "cniVersion": "1.0.0",
+  "name": "crio",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ],
+        "ranges": [
+            [{ "subnet": "10.85.0.0/16" }]
+        ]
+      }
+    }
+  ]
+}

--- a/tasks/crio.yaml
+++ b/tasks/crio.yaml
@@ -9,35 +9,13 @@
     enablerepo: microshift-deps-rpms
   notify: Restart crio
 
-- name: Get cri-o version
-  ansible.builtin.shell: |
-    rpm -qa --qf '%{VERSION}' cri-o
-  tags:
-    - skip_ansible_lint
-  register: _crio_version
-  changed_when: false
-
-- name: Use only ipv4 - new Microshift
+- name: Use only ipv4
   become: true
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conflist
+  ansible.builtin.copy:
+    src: crio-bridge.conf
     dest: /etc/cni/net.d/100-crio-bridge.conf
     mode: "0644"
   notify: Restart crio
-  when: microshift_version > 4.12
-  retries: 6
-  delay: 10
-
-- name: Use only ipv4 - legacy Microshift
-  become: true
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/cri-o/cri-o/v{{ _crio_version.stdout }}/contrib/cni/11-crio-ipv4-bridge.conf
-    dest: /etc/cni/net.d/100-crio-bridge.conf
-    mode: "0644"
-  notify: Restart crio
-  when: microshift_version <= 4.12
-  retries: 6
-  delay: 10
 
 - name: Apply container policy from crc
   become: true


### PR DESCRIPTION
This current method currenlty fails because the detected version is not avaible as a git tag on github.com.

TASK [/home/zuul-worker/ansible-microshift-role : Use only ipv4 - new Microshift] ***
fatal: [microshift]: FAILED! => {"changed": false, "dest": "/etc/cni/net.d/100-crio-bridge.conf", "elapsed": 0, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "status_code": 404, "url": "https://raw.githubusercontent.com/cri-o/cri-o/v1.26.5/contrib/cni/11-crio-ipv4-bridge.conflist"}

This change simplifies the installation by provisionning the file directly in the role.