### PR TITLE
Change repository directory

### DIFF
--- a/templates/microshift.repo.j2
+++ b/templates/microshift.repo.j2
@@ -3,7 +3,7 @@ name=Puddle of Microshift RPMs
 {% if microshift_version == 4.12 %}
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el8/os/
 {% else %}
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-{{ microshift_version }}/el{{ ansible_distribution_major_version }}/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp/latest-{{ microshift_version }}/el{{ ansible_distribution_major_version }}/os/
 {% endif %}
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
This commit is more a cosmetic change, because packages for few releases are same in both location - ocp and ocp-dev-preview, but it might happen, that there would be different version there. To avoid situation, that we would be able to install preview version, let's change the repository url to official.