### PR TITLE
Print storage information when wait for microshift script fails

### DIFF
--- a/files/wait-for-microshift.sh
+++ b/files/wait-for-microshift.sh
@@ -29,4 +29,13 @@ oc get pods --all-namespaces --no-headers | grep -Evi 'running|completed' | whil
     kubectl -n "${ns}" describe pod "${pod}";
     kubectl -n "${ns}" logs "${pod}" || true
 done
+
+# Print additional information related to the storage
+systemctl status microshift-loop-device
+losetup
+lsblk
+sudo vgdisplay
+sudo lvdisplay
+sudo vgs
+
 exit 1


### PR DESCRIPTION
From time to time, the script wait-for-microshift.sh is failing because it is waiting for topolvm to be ready. It stuck on some point. Let's print such information, that might be useful for administrator to see where is an error.