### PR TITLE
Change storage deployment order in Microshift setup; ensure vg is created

### DIFF
--- a/tasks/openshift-storage.yaml
+++ b/tasks/openshift-storage.yaml
@@ -63,8 +63,31 @@
             enabled: true
             daemon_reload: true
 
+        - name: Wait for microshift-loop-device service to be active
+          ansible.builtin.command: systemctl is-active microshift-loop-device
+          register: systemd_result
+          until: "'inactive' not in systemd_result.stdout"
+          retries: 10
+          delay: 5
+
+        - name: Get loop device list
+          become: true
+          ansible.builtin.command: losetup --list
+          register: _losetup_list
+
         - name: Create volume group
           become: true
           community.general.lvg:
             vg: "{{ vg_name }}"
             pvs: "{{ loop_device.stdout }}"
+
+        - name: Get information about volume groups
+          become: true
+          ansible.builtin.command: vgdisplay
+          register: _vg_list
+
+        - name: Ensure that loop device and volume group are present
+          ansible.builtin.assert:
+            that:
+            - loop_device.stdout in _losetup_list.stdout
+            - vg_name in _vg_list.stdout


### PR DESCRIPTION
In this commit, the tasks responsible for creating the loop device setup and disk creation are moved to earlier stage.
Also added tasks, that ensure if volume group, logical volume and loop device are created properly.