### PR TITLE
Fix OLM installation; remove repo_dir var; move operator-sdk to other dir

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -98,11 +98,6 @@ setup_olm: false
 # https://github.com/operator-framework/operator-lifecycle-manager/releases
 olm_version: "v0.28.0"
 
-# Location where the additional projects should be keeped.
-# For example, if `setup_olm` is enabled, it will use Git to clone project
-# to that directory.
-repo_dir: "~{{ ansible_user }}/repos"
-
 # Version of the Operator SDK
 # https://github.com/operator-framework/operator-sdk/releases
 operator_sdk_version: "v1.34.2"

--- a/tasks/olm.yaml
+++ b/tasks/olm.yaml
@@ -1,22 +1,16 @@
 ---
-- name: Ensure installation directory
-  ansible.builtin.file:
-    path: "{{ repo_dir }}"
-    state: directory
-    mode: "0755"
-
 - name: Fetch operator-sdk
+  become: true
   ansible.builtin.uri:
     url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_amd64
-    dest: "{{ repo_dir }}/operator-sdk"
+    dest: /usr/local/bin/operator-sdk
     mode: "755"
     status_code:
       - 200
       - 304
 
 - name: Check if OLM is installed
-  ansible.builtin.command:
-    "{{ repo_dir }}/operator-sdk olm status"
+  ansible.builtin.command: /usr/local/bin/operator-sdk olm status
   register: olm_status
   failed_when: olm_status.rc not in [0, 1]
   changed_when: true
@@ -32,7 +26,7 @@
     - "olm-operator-serviceaccount"
 
 - name: Install OLM with SDK
-  ansible.builtin.command:
-    "{{ repo_dir }}/operator-sdk olm install --version {{ olm_version }}"
+  ansible.builtin.command: |
+    /usr/local/bin/operator-sdk olm install --version {{ olm_version }}
   when: olm_status.rc != 0
   changed_when: true


### PR DESCRIPTION
The ansible is failing when tasks responsible for olm are triggered. Also changed a place for the binary: operator-sdk to better place (that binary might be useful in the future).