### PR TITLE
Add baseDomain name and subjectAltName that is pointing to host ip address

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -47,11 +47,12 @@ microshift_config:
   apiServer:
     subjectAltNames:
       - "{{ fqdn }}"
+      - "{{ ansible_default_ipv4.address }}"
 #    advertiseAddress: ""
+  dns:
+    baseDomain: "{{ fqdn }}"
 #  debugging:
 #    logLevel: Normal
-#  dns:
-#    baseDomain: example.com
 #  etcd:
 #    memoryLimitMB: 0
 #  manifests:


### PR DESCRIPTION
The cert should be extended to additional informations.
Also instead of setting the domain in the DNSMasq, we can set it in
MicroShift config.