### PR TITLE
Create vg and lvm before MicroShift starts

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -32,15 +32,15 @@
   ansible.builtin.include_tasks: etcd_ramdisk.yaml
   when: etcd_on_ramdisk
 
+- name: Create VG and LVM for openshift-storage topolvm
+  ansible.builtin.include_tasks: openshift-storage.yaml
+
 - name: Setup Microshift
   ansible.builtin.include_tasks: microshift.yaml
 
 - name: Provide credentials for restricted regitries
   ansible.builtin.include_tasks: registry_login.yaml
   when: not use_copr_microshift
-
-- name: Create lvm or delete openshift storage
-  ansible.builtin.include_tasks: openshift-storage.yaml
 
 - name: Verify that Microshift deployment is finished
   ansible.builtin.include_tasks: wait-for-microshift.yaml


### PR DESCRIPTION
The vg should be available before the MicroShift start. It will take less time to finish the deployment.