### PR TITLE
Change back order to provision openshift-storage

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -32,9 +32,6 @@
   ansible.builtin.include_tasks: etcd_ramdisk.yaml
   when: etcd_on_ramdisk
 
-- name: Create VG and LVM for openshift-storage topolvm
-  ansible.builtin.include_tasks: openshift-storage.yaml
-
 - name: Setup Microshift
   ansible.builtin.include_tasks: microshift.yaml
 
@@ -43,6 +40,12 @@
   when: not use_copr_microshift
 
 - name: Verify that Microshift deployment is finished
+  ansible.builtin.include_tasks: wait-for-microshift.yaml
+
+- name: Create VG and LVM for openshift-storage topolvm
+  ansible.builtin.include_tasks: openshift-storage.yaml
+
+- name: Wait for the openshift-storage to be deployed
   ansible.builtin.include_tasks: wait-for-microshift.yaml
 
 - name: Configure DNSMasq


### PR DESCRIPTION
After changing an order, the openshift-storage is not deploying anymore. Let's go back and re-run wait script to ensure, that the whole deployment is up and ready.