### PR TITLE
Add lvm information for storageclass

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -72,13 +72,13 @@ microshift_config:
 
 # Default settings from /etc/microshift/lvmd.yaml.default
 # https://github.com/openshift/microshift/blob/release-4.14/packaging/microshift/lvmd.yaml
-microshift_lmvd: {}
+microshift_lmvd:
 # socket-name: /run/lvmd/lvmd.socket
-# device-classes:
-#   - name: default
-#     volume-group: rhel
+ device-classes:
+   - name: default
+     volume-group: rhel
+     default: true
 #     spare-gb: 0
-#     default: true
 #     stripe: ""
 #     stripe-size: ""
 #     lvcreate-options:


### PR DESCRIPTION
It seems that in the new MicroShift version, the volume group (vg) name has changed and the default value is not "rhel" as it was. Even when we set the value to "rhel" to avoid situation, that on some hosts when we perform an upgrade we can loose data, the MicroShift is also creating vg with name "sc".