### PR TITLE
Add workaround to install Open vSwitch in version 3.1

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -15,6 +15,12 @@
         state: present
       notify: Restart Microshift
 
+- name: Install CentOS NFV repository to enable Open vSwitch
+  become: true
+  ansible.builtin.yum:
+    name: centos-release-nfv-openvswitch
+    state: present
+
 - name: Install microshift package
   become: true
   ansible.builtin.yum:


### PR DESCRIPTION
The openvswitch3.1 is required by the microshift-networking package. The package has been updated in the MicroShift deps repository. Until the package is not back there, let's try to use CentOS NFV package.