### PR TITLE
Add version file if it does not exists

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -30,6 +30,20 @@
   notify: Restart Microshift
   when: not use_copr_microshift
 
+- name: Check if version file exists
+  become: true
+  ansible.builtin.stat:
+    path: /var/lib/microshift/version
+  register: _microshift_version_file
+
+- name: "Create a version file if does not exists with version {{ microshift_version }}.0"
+  become: true
+  when: not _microshift_version_file.stat.exists
+  ansible.builtin.copy:
+    content: |
+      {{ microshift_version }}.0
+    dest: /var/lib/microshift/version
+
 - name: Change Microshift configuration files
   become: true
   ansible.builtin.copy:


### PR DESCRIPTION
The new MicroShift service (>4.14) can not start, because it is raising an error:

    version.go:240] "START reading version file"
    version.go:243] "FAIL reading version file" err="version file for MicroShift data does not exist"
    version.go:127] "MicroShift data directory exists, but doesn't contain version file - assuming 4.13.0 and proceeding with versio>
    version.go:54] "END getting versions" exec="4.16.0" data="4.13.0"
    version.go:59] "START version compatibility checks"

This commit is adding the version file, so there is no need to install older MicroShift version.