### PR TITLE
Ensure the /var/lib/microshift dir exists

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -30,6 +30,12 @@
   notify: Restart Microshift
   when: not use_copr_microshift
 
+- name: Ensure microshift lib dir exists
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/microshift
+    state: directory
+
 - name: Check if version file exists
   become: true
   ansible.builtin.stat:


### PR DESCRIPTION
Normally the dir should be created by the rpm package, but in the CI, it is complaying, that the dir is missing (not all the time).