### PR TITLE
Bump default MicroShift version to 4.16; update OperatorSDK to 1.36.1

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -39,7 +39,7 @@ firewalld_rules_permament: true
 use_copr_microshift: false
 
 # The Microshift version that is available in the repository.
-microshift_version: 4.14
+microshift_version: 4.16
 
 # Default settings from /etc/microshift/config.yaml.default
 # https://github.com/openshift/microshift/blob/release-4.14/packaging/microshift/config.yaml
@@ -101,7 +101,7 @@ olm_version: "v0.28.0"
 
 # Version of the Operator SDK
 # https://github.com/operator-framework/operator-sdk/releases
-operator_sdk_version: "v1.34.2"
+operator_sdk_version: "v1.36.1"
 
 #######################################
 ###        Openshift Storage        ###


### PR DESCRIPTION
The MicroShift 4.16 is marked as LTS release [1][2].

[1] https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.16/html-single/installing/index#microshift-install-system-requirements_microshift-install-rpm
[2] https://access.redhat.com/product-life-cycles