### PR TITLE
Change ansible_distribution from rhel to redhat

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -5,7 +5,7 @@
   when: not openshift_pull_secret
 
 - name: Configure required resources for non RHEL distro
-  when: ansible_distribution | lower != 'rhel'
+  when: ansible_distribution | lower != 'redhat'
   block:
     - name: Setup Microshift repository
       ansible.builtin.include_tasks: repo.yaml
@@ -21,7 +21,7 @@
       ansible.builtin.include_tasks: crio.yaml
 
 - name: Configure RHEL subscription
-  when: ansible_distribution | lower == 'rhel'
+  when: ansible_distribution | lower == 'redhat'
   ansible.builtin.include_tasks: subscription.yaml
 
 - name: Prepare firewall

--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Install Microshift when distro is not RHEL
-  when: ansible_distribution | lower != 'rhel'
+  when: ansible_distribution | lower != 'redhat'
   block:
     - name: Install CentOS NFV repository to enable Open vSwitch
       become: true
@@ -17,7 +17,7 @@
       notify: Restart Microshift
 
 - name: Install Microshift when distro is RHEL
-  when: ansible_distribution | lower == 'rhel'
+  when: ansible_distribution | lower == 'redhat'
   become: true
   ansible.builtin.yum:
     name: microshift


### PR DESCRIPTION
Some "when" clauses check the os version by the value of Rhel instead of RedHat.