### PR TITLE
Add task to upgrade RHEL from one minor version to another

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -3,6 +3,10 @@
 ###       Basic configuration       ###
 #######################################
 
+# RHEL Version
+rhel_version_origin: "9.3"
+rhel_version_target: "9.4"
+
 # Set the Fully Qualified Domain Name of a Microshift host
 fqdn: microshift.dev
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -20,9 +20,18 @@
     - name: Prepare cri-o
       ansible.builtin.include_tasks: crio.yaml
 
-- name: Configure RHEL subscription
+- name: Configure RHEL subscription and update to the latest minor version
+  block:
+
+    - name: Configure Subscription
+      ansible.builtin.include_tasks: subscription.yaml
+
+    - name: Update RHEL OS minor version
+      when:
+        - ansible_distribution_version != rhel_version_target
+      ansible.builtin.include_tasks: update-rhel-minor-version.yaml
+
   when: ansible_distribution | lower == 'redhat'
-  ansible.builtin.include_tasks: subscription.yaml
 
 - name: Prepare firewall
   ansible.builtin.include_tasks: firewall.yaml

--- a/tasks/update-rhel-minor-version.yaml
+++ b/tasks/update-rhel-minor-version.yaml
@@ -1,0 +1,27 @@
+---
+# Thess tasks upgrades the RHEL OS to the target minor version set by
+# the variable rhel_version_target
+- name: Upgrade all packages before update
+  when: ansible_distribution_version == rhel_version_origin
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+
+- name: Set Sticky OS version
+  when: ansible_distribution_version == rhel_version_origin
+  ansible.builtin.command:
+    cmd: subscription-manager release --set {{ rhel_version_target }}
+
+- name: Update Facts
+  ansible.builtin.setup:
+
+- name: Upgrade all packages after repo update
+  when: ansible_distribution_version == rhel_version_target
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+
+- name: Reboot System
+  when: ansible_distribution_version == rhel_version_target
+  ansible.builtin.reboot:
+    reboot_timeout: 3600


### PR DESCRIPTION
This change adds tasks to upgrade RHEL OS from an minor origin version to a target version.
The origin and targer versions are set by the rhel_version_origin and rhel_version_target versions.