### PR TITLE
Add enable_rhocp_subscription variable to disable RHEL subscription

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -10,6 +10,10 @@ fqdn: microshift.dev
 # It can be generated here: https://cloud.redhat.com/openshift/create/local
 openshift_pull_secret: ""
 
+# Enable RHOCP subscription repo to install MicroShift rpm packages
+# on RHEL systems
+enable_rhocp_subscription: true
+
 # Set the location, where the pull-secret.txt content will be stored,
 # Later it will be used by cri-o runtime environment.
 registry_secret_path: /etc/crio/openshift-pull-secret

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -21,7 +21,7 @@
       ansible.builtin.include_tasks: crio.yaml
 
 - name: Configure RHEL subscription
-  when: ansible_distribution | lower == 'redhat'
+  when: ansible_distribution | lower == 'redhat' and enable_rhocp_subscription
   ansible.builtin.include_tasks: subscription.yaml
 
 - name: Prepare firewall


### PR DESCRIPTION
On some host, it might be running old MicroShift installation, which should not be updated directly to newest version.

To disable enabling RHEL subscription, set enable_rhocp_subscription variable to false.