### PR TITLE
Add conditions to install Microshift without subscription

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Install Microshift when distro is not RHEL
-  when: ansible_distribution | lower != 'redhat'
+  when: ansible_distribution | lower != 'redhat' or not enable_rhocp_subscription
   block:
     - name: Install CentOS NFV repository to enable Open vSwitch
       become: true
@@ -17,7 +17,7 @@
       notify: Restart Microshift
 
 - name: Install Microshift when distro is RHEL
-  when: ansible_distribution | lower == 'redhat'
+  when: ansible_distribution | lower == 'redhat' and enable_rhocp_subscription
   become: true
   ansible.builtin.yum:
     name: microshift


### PR DESCRIPTION
The condition was already done in commit [1][2] to the main task file, but it was not added into the microshift task file.

[1] https://github.com/openstack-k8s-operators/ansible-microshift-role/pull/86
[2] https://github.com/openstack-k8s-operators/ansible-microshift-role/pull/87