### PR TITLE
 Enable fast-datapath-for-rhel subscription in old way

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -155,3 +155,7 @@ etcd_on_ramdisk: false
 ramdisk_path: /var/lib/microshift/etcd
 # Ramdisk size for etcd service
 ramdisk_size: 512m
+
+# NOTE: Temporary workaround to install package that is not available on RHEL,
+# until the project supports CentOS and RHEL deployment.
+centos_rpm_nfv_direct_url: https://mirror.stream.centos.org/SIGs/9-stream/extras/x86_64/extras-common/Packages/c/centos-release-nfv-openvswitch-1-5.el9s.noarch.rpm

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -21,7 +21,7 @@
       ansible.builtin.include_tasks: crio.yaml
 
 - name: Configure RHEL subscription
-  when: ansible_distribution | lower == 'redhat' and enable_rhocp_subscription
+  when: ansible_distribution | lower == 'redhat'
   ansible.builtin.include_tasks: subscription.yaml
 
 - name: Prepare firewall

--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -2,7 +2,8 @@
 - name: Install Microshift when distro is not RHEL
   when: ansible_distribution | lower != 'redhat' or not enable_rhocp_subscription
   block:
-    - name: Install CentOS NFV repository to enable Open vSwitch
+    - name: Install CentOS NFV repository to enable Open vSwitch if not RHEL
+      when: ansible_distribution | lower != 'redhat'
       become: true
       ansible.builtin.yum:
         name: centos-release-nfv-openvswitch

--- a/tasks/subscription.yaml
+++ b/tasks/subscription.yaml
@@ -1,6 +1,9 @@
 ---
 # https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.16/html/installing/microshift-install-rpm#installing-microshift-from-rpm-package_microshift-install-rpm
+# NOTE: drop enable_rhocp_subscription condition, when CentOS support
+# would be removed.
 - name: Enable RHOCP repso
+  when: enable_rhocp_subscription
   become: true
   community.general.rhsm_repository:
     name: "rhocp-4.16-for-rhel-9-{{ ansible_architecture }}-rpms"


### PR DESCRIPTION
Enable fast-datapath-for-rhel subscription in old way

On RHEL system, if someone wants to install the MicroShift in old way,
it will miss required package: centos-release-nfv-openvswitch
that is necessary to deploy MicroShift (it provides Open vSwitch).
The package installation requires few other packages, that might make
the RHEL system unstable, so it is more safe to enable fast-datapath-for-rhel
subscription.

This is a temporary workaround until we drop CentOS support for
that project (only RHOCP version would be available).

NOTE: Without this patch, installing legacy version on RHEL will be not possible due it require Open vSwitch.
This pull request is just helpful for community. The CI and dev hosts will use RHOCP version. We can drop that PR if we decide that installing old rpm packages RHEL system is not necessary.