### PR TITLE
Set spare-gb parameter to 0

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -71,7 +71,7 @@ microshift_lmvd:
    - name: default
      volume-group: rhel
      default: true
-#     spare-gb: 0
+     spare-gb: 0
 #     stripe: ""
 #     stripe-size: ""
 #     lvcreate-options:


### PR DESCRIPTION
When the volume group size is too small, setting spare-gb to 0 can lead to scheduling errors, such as:

     0/1 nodes are available: 1 node(s) did not have enough free storage.
     preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.

This change might cause issues with dynamic volume provisioning due to insufficient spare space. For more information on the impact of spare-gb, see documentation at [1].

[1] https://github.com/topolvm/topolvm/blob/main/docs/proposals/lvcreate-option-on-storageclass.md