### PR TITLE
Do not check if RHEL release is 9.4

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,8 +7,7 @@
 - name: Check system version compatibility
   ansible.builtin.fail:
     msg: "The system is not compatible"
-  when: (ansible_distribution_version != '9.4') or
-        (ansible_distribution | lower != 'redhat')
+  when: ansible_distribution | lower != 'redhat'
 
 - name: Configure RHEL subscription
   ansible.builtin.include_tasks: subscription.yaml


### PR DESCRIPTION
The value should be set in the CI, not in the project directly. Otherwise we also should change MicroShift version to newer.