### PR TITLE
Disable dnsmasq

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -118,7 +118,7 @@ vg_name: rhel
 
 # Configure the DNSMasq service to redirect service addresses to proper
 # ip address.
-configure_dnsmasq: true
+configure_dnsmasq: false
 # Set the ip address of remote Microshift machine to configure local
 # DNSMasq service to redirect DNS queries for {{ fqdn }} domain
 # to the Microshift machine. If the value is empty, it will configure


### PR DESCRIPTION
The CI tests in sf-operator project will use hostAliases [1][2], so the workaround for discovering local domains are not needed.

[1] https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
[2] https://softwarefactory-project.io/r/c/software-factory/sf-operator/+/32944