### PR TITLE
Change condition to support RHEL 9.2

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,7 +7,7 @@
 - name: Check system version compatibility
   ansible.builtin.fail:
     msg: "The system is not compatible"
-  when: (ansible_distribution_version != '9.4') or
+  when: (ansible_distribution_version is version('9.2', '<')) or
         (ansible_distribution | lower != 'redhat')
 
 - name: Configure RHEL subscription


### PR DESCRIPTION
According to the doc [1], minimal RHEL version is 9.2. Same version is set in README.md file [2].

[1] https://github.com/openshift/microshift#system-requirements
[2] https://github.com/openstack-k8s-operators/ansible-microshift-role#role-requirements