### PR TITLE
Add variable responsible for MicroShift version

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -6,6 +6,9 @@
 # Set the Fully Qualified Domain Name of a Microshift host
 fqdn: microshift.dev
 
+# Set MicroShift release / OCP version
+microshift_version: 4.18
+
 # NOTE: To deploy Microshift > 4.8, you should provide pull-secret.txt content.
 # It can be generated here: https://cloud.redhat.com/openshift/create/local
 openshift_pull_secret: ""

--- a/tasks/subscription.yaml
+++ b/tasks/subscription.yaml
@@ -1,9 +1,9 @@
 ---
 # https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.16/html/installing/microshift-install-rpm#installing-microshift-from-rpm-package_microshift-install-rpm
-- name: Enable RHOCP repository
+- name: "Enable RHOCP repository for microshift version {{ microshift_version }}"
   become: true
   community.general.rhsm_repository:
-    name: "rhocp-4.16-for-rhel-9-{{ ansible_architecture }}-rpms"
+    name: "rhocp-{{ microshift_version }}-for-rhel-9-{{ ansible_architecture }}-rpms"
     state: enabled
 
 - name: Enable fast datapath repository


### PR DESCRIPTION
By default, the role was installing OCP 4.16, where it should be parametrized.
Add new variable that would setup desired version.

Also update the release from 4.16 to 4.18.