### PR TITLE
Fix broken conditionals

### DIFF
--- a/tasks/microshift.yaml
+++ b/tasks/microshift.yaml
@@ -29,7 +29,7 @@
       dest: config.yaml
     - var_name: microshift_lmvd
       dest: lvmd.yaml
-  when: vars[item.var_name]
+  when: vars[item.var_name] is defined
   register: microshift_config
 
 - name: Restart Microshift if config changed


### PR DESCRIPTION
This change fixes the following error:

  [ERROR]: Task failed: Conditional result (True) was derived from value of type 'dict' at 'defaults/main.yaml:32:3'. Conditionals must have a boolean result.